### PR TITLE
Web UI improvements for Apache Drill

### DIFF
--- a/exec/java-exec/src/main/resources/rest/generic.ftl
+++ b/exec/java-exec/src/main/resources/rest/generic.ftl
@@ -65,6 +65,9 @@
             <ul class="nav navbar-nav">
               <li><a href="/query">Query</a></li>
               <li><a href="/profiles">Profiles</a></li>
+            </ul>
+            </#if>
+            <ul class="nav navbar-nav navbar-right">
               <#if showStorage == true>
               <li><a href="/storage">Storage</a></li>
               </#if>
@@ -75,9 +78,6 @@
               <#if showLogs == true>
                   <li><a href="/logs">Logs</a></li>
               </#if>
-            </ul>
-            </#if>
-            <ul class="nav navbar-nav navbar-right">
               <#if showOptions == true>
               <li><a href="/options">Options</a></li>
               </#if>

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -29,6 +29,9 @@
   <script src="/static/js/ace-code-editor/theme-sqlserver.js" type="text/javascript" charset="utf-8"></script>
   <script src="/static/js/ace-code-editor/snippets/sql.js" type="text/javascript" charset="utf-8"></script>
   <script src="/static/js/ace-code-editor/mode-snippets.js" type="text/javascript" charset="utf-8"></script>
+  <style>
+    html, body, .container-fluid[role=main], #query-body { height: 95%; }
+  </style>
 </#macro>
 
 <#macro page_body>
@@ -36,7 +39,7 @@
   </div>
   <div id="message" class="alert alert-info alert-dismissable" style="font-family: courier,monospace;">
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-    Sample SQL query: <strong>SELECT * FROM cp.`employee.json` LIMIT 20</strong>
+    Sample SQL query: <strong>SELECT * FROM kafka.topic_name LIMIT 20</strong>
   </div>
 
 <#include "*/alertModals.ftl">
@@ -50,41 +53,48 @@
      </div>
   </#if>
 
-  <form role="form" id="queryForm" action="/query" method="POST">
-      <div class="form-group">
-      <label for="queryType">Query Type</label>
-      <div class="radio">
-        <label>
-          <input type="radio" name="queryType" id="sql" value="SQL" checked>
-          SQL
-        </label>
-      </div>
-      <div class="radio">
-        <label>
-          <input type="radio" name="queryType" id="physical" value="PHYSICAL">
-          PHYSICAL
-        </label>
-      </div>
-      <div class="radio">
-        <label>
-          <input type="radio" name="queryType" id="logical" value="LOGICAL">
-          LOGICAL
-        </label>
-      </div>
-    </div>
-    <div class="form-group">
-      <div style="display: inline-block"><label for="query">Query</label></div>
-      <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
-      <div id="query-editor-format"></div>
-      <input class="form-control" type="hidden" id="query" name="query" autofocus/>
-    </div>
+  <div id="query-body" style="display: flex;">
+    <div style="flex: 40%;">
+      <form role="form" id="queryForm" action="/query" method="POST">
+        <div class="form-group" style="display: none">
+          <label for="queryType">Query Type</label>
+          <div class="radio">
+            <label>
+              <input type="radio" name="queryType" id="sql" value="SQL" checked>
+              SQL
+            </label>
+          </div>
+          <div class="radio">
+            <label>
+              <input type="radio" name="queryType" id="physical" value="PHYSICAL">
+              PHYSICAL
+            </label>
+          </div>
+          <div class="radio">
+            <label>
+              <input type="radio" name="queryType" id="logical" value="LOGICAL">
+              LOGICAL
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <div style="display: inline-block"><label for="query">Query</label></div>
+          <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
+          <div id="query-editor-format"></div>
+          <input class="form-control" type="hidden" id="query" name="query" autofocus/>
+        </div>
 
-    <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
-      Submit
-    </button>
-    <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
-    <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
-  </form>
+        <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
+          Submit
+        </button>
+        <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
+        <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
+      </form>
+    </div>
+    <div style="flex: 60%;">
+      <iframe id="query-results" style="border: none; height: 100%; width: 100%;"></iframe>
+    </div>
+  </div>
 
   <script>
     // Remember form field values over page reloads

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -24,6 +24,9 @@
     <link href="/static/css/dataTables.colVis-1.1.0.min.css" rel="stylesheet">
     <link href="/static/css/dataTables.jqueryui.css" rel="stylesheet">
     <link href="/static/css/jquery-ui-1.10.3.min.css" rel="stylesheet">
+    <style>
+      .page-header, .navbar[role=navigation] { display: none }
+    </style>
 </#macro>
 
 <#macro page_body>

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -95,7 +95,7 @@ function submitQuery() {
         data: $("#queryForm").serializeArray(),
         success: function (response) {
             closePopup();
-            var newDoc = document.open("text/html", "replace");
+            var newDoc = document.getElementById('query-results').contentWindow.document;
             newDoc.write(response);
             newDoc.close();
         },


### PR DESCRIPTION
`master` of this fork is to be used to sync with upstream. 
`master-shopify` will be used for our changes, and can rebase off `master`. https://github.com/Shopify/drill/tree/master-shopify

Docker image: https://github.com/Shopify/shopify-docker-images/pull/1694

## Description
https://github.com/Shopify/streaming-platform/issues/396
This PR implements UI changes as suggested from a UX review and user feedback.

---
**1. Relevant tooltip**

Everyone has had their first query fail because they didn't specify to query from Kafka.
![image](https://user-images.githubusercontent.com/24235441/76095787-ddd7e900-5f92-11ea-8864-59675b22162f.png)

---
**2. Separation of relevant tabs**

Developers using Kafka really only care about querying and query history (profiles). Moved all administrative tabs to the right of the navbar.
![image](https://user-images.githubusercontent.com/24235441/76096030-59d23100-5f93-11ea-97fe-7c1e5f0756a7.png)

---
**3. Removal of logical/physical querying**

Queries are being written exclusively in SQL, so "Query Type" block has been removed.
![image](https://user-images.githubusercontent.com/24235441/76096839-ad914a00-5f94-11ea-95e5-e560698ed040.png)

---
**4. Display results next to query**

Query results currently overwrite page HTML, meaning that you have to navigate back to the query page and rewrite your query if you want to run another query.  Instead, write the results HTML into an iframe beside the query form so that both query and results are visible.
![image](https://user-images.githubusercontent.com/24235441/76097087-1678c200-5f95-11ea-8828-347cfecc5a23.png)

## Testing
I have tophatted this change locally.