### PR TITLE
Add dropdown to select default storage

### DIFF
--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -82,7 +82,17 @@
       Submit
     </button>
     <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
-    <label> Default Schema <input type="text" size="10" name="defaultSchema" id="defaultSchema"> </label>
+    <label> Default Schema </label>
+    <select name="defaultSchema" id="defaultSchema">
+      <#if model.getEnabledPlugins()?size gt 1>
+        <option value> -- select default schema -- </option>
+      </#if>
+      <#list model.getEnabledPlugins() as pluginModel>
+        <#if pluginModel.getPlugin()?? && pluginModel.getPlugin().enabled() == true>
+          <option value="${pluginModel.getPlugin().getName()}">${pluginModel.getPlugin().getName()}</option>
+        </#if>
+      </#list>
+    </select>
     <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names, and for SHOW FILES and SHOW TABLES" style="cursor:pointer"></span>
     <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
   </form>
@@ -114,6 +124,10 @@
       } else {
         if (typeof savedValue === "string") {
           $input.val(savedValue);
+          // Reset to first option if saved value is no longer an option
+          if ($input.is("select") && $input.val() === null) {
+            $input.prop("selectedIndex", 0);
+          }
         }
         $input.change(function () {
           sessionStorage.setItem(savedKey, $(this).val());


### PR DESCRIPTION
# [DRILL-7692](https://issues.apache.org/jira/browse/DRILL-7692): Select default schema from enabled storage plugins in query page
## Description
In v1.18.0, users specify a schema through an input field but this is error prone and doesn't restrict options to enabled storage plugins.

![image](https://user-images.githubusercontent.com/24235441/78713950-08e28f00-78e9-11ea-9085-a5cacda280ac.png)

 I propose that it be changed to a dropdown that lists enabled storages as options, and automatically defaults if there is only one available storage.

![image](https://user-images.githubusercontent.com/24235441/78830136-7a880f00-79b5-11ea-8805-4091ad261720.png)



## Documentation
N/A

## Testing
Manually tested through Web UI both locally and in Shopify's Drill deployment
https://drill.shopifycloud.com/query